### PR TITLE
unharmful improvement on cd

### DIFF
--- a/scripts/build_environment/GC-classic/bashrc/personal
+++ b/scripts/build_environment/GC-classic/bashrc/personal
@@ -14,13 +14,13 @@ function cdls() {
 # first do 'cd'
 command cd $@  #'command' ensures we use original 'cd'
 # then do 'ls'
-nfiles=$(ls -1 | wc -l) # how many files
+nfiles=$(ls | wc -l) # how many files
 if [ $nfiles -lt 60 ] # list all files if not too many
 then
   ls
 else
   ls | head -n 4
-  echo $nfiles ' files in total, only list a few'
+  echo $nfiles 'files in total, only list a few'
 fi
 }
 


### PR DESCRIPTION
1. I found that the output from `ls | wc -l` is less than that from `ls -l | wc -l` by 1 but the former is the exactly the number of files within a directory.
2. `echo` will place spaces between consecutive command arguments automatically.